### PR TITLE
Add SignoutUser to reset password

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.EmployerUsers.Web/Controllers/AccountController.cs
@@ -323,6 +323,9 @@ namespace SFA.DAS.EmployerUsers.Web.Controllers
                 return new HttpStatusCodeResult((int)HttpStatusCode.BadRequest);
             }
 
+            _owinWrapper.RemovePartialLoginCookie();
+            _owinWrapper.SignoutUser();
+
             return View("ForgottenCredentials", model);
         }
 


### PR DESCRIPTION
Make sure that we signout the user when doing the reset password
password route so we dont get an error with the Anitforgery token being
issued for a different Id.