### PR TITLE
Fix bug where going to root of IdP causes error

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Web/Controllers/HomeController.cs
+++ b/src/SFA.DAS.EmployerUsers.Web/Controllers/HomeController.cs
@@ -2,6 +2,7 @@
 using NLog;
 using SFA.DAS.EmployerUsers.Infrastructure.Configuration;
 using SFA.DAS.EmployerUsers.Web.Authentication;
+using SFA.DAS.EmployerUsers.Web.Models;
 
 namespace SFA.DAS.EmployerUsers.Web.Controllers
 {
@@ -24,16 +25,17 @@ namespace SFA.DAS.EmployerUsers.Web.Controllers
             if (!string.IsNullOrEmpty(returnUrl))
             {
                 Logger.Info($"HomeController:Index - Redirecting user out of iDams to {returnUrl}");
-                return Redirect(returnUrl);
+                return View(new HomePageViewModel { ReturnUrl = returnUrl });
             }
+
             returnUrl = _identityServerConfiguration.EmployerPortalUrl;
             Logger.Info($"HomeController:Index - Redirecting user out of iDams (brute force) to {returnUrl}");
-            return View(_identityServerConfiguration.EmployerPortalUrl);
+            return View(new HomePageViewModel { ReturnUrl = _identityServerConfiguration.EmployerPortalUrl });
         }
 
         public ActionResult CatchAll(string path)
         {
-            return RedirectToAction("NotFound", "Error", new {path});
+            return RedirectToAction("NotFound", "Error", new { path });
         }
 
         [HttpGet]

--- a/src/SFA.DAS.EmployerUsers.Web/Models/HomePageViewModel.cs
+++ b/src/SFA.DAS.EmployerUsers.Web/Models/HomePageViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace SFA.DAS.EmployerUsers.Web.Models
+{
+    public class HomePageViewModel
+    {
+        public string ReturnUrl { get; set; }
+    }
+}

--- a/src/SFA.DAS.EmployerUsers.Web/SFA.DAS.EmployerUsers.Web.csproj
+++ b/src/SFA.DAS.EmployerUsers.Web/SFA.DAS.EmployerUsers.Web.csproj
@@ -329,6 +329,7 @@
     <Compile Include="App_Start\LoggingConfig.cs" />
     <Compile Include="App_Start\SystemWebCookieManager.cs" />
     <Compile Include="Authentication\IdsContext.cs" />
+    <Compile Include="Models\HomePageViewModel.cs" />
     <Compile Include="Plumbing\Ids\RedisAuthorizationCodeStore.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="Plumbing\Ids\StartsWithRedirectUriValidator.cs" />

--- a/src/SFA.DAS.EmployerUsers.Web/Views/Error/NotFound.cshtml
+++ b/src/SFA.DAS.EmployerUsers.Web/Views/Error/NotFound.cshtml
@@ -3,5 +3,5 @@
     ViewBag.PageID = "page-not-found";
 }
 
-    <h1 class="heading-xlarge">@ViewBag.Title</h1>
-    <p>If you entered a web address, check that it's correct. </p>
+<h1 class="heading-xlarge">@ViewBag.Title</h1>
+<p>If you entered a web address, check that it's correct. </p>

--- a/src/SFA.DAS.EmployerUsers.Web/Views/Home/Index.cshtml
+++ b/src/SFA.DAS.EmployerUsers.Web/Views/Home/Index.cshtml
@@ -1,13 +1,16 @@
-﻿@{
-    ViewBag.Title = "Welcome";
-}
-<h1 class="heading-xlarge">Welcome</h1>
-<div class="form-group">
-@if (HttpContext.Current.User.Identity.IsAuthenticated)
-{
-    <a href="@Url.Action("Logout", "Account")" class="button">Log out</a>
-} else {
-    <a href="@Url.Action("Login","Home")" class="button">Sign in</a> 
+﻿@model SFA.DAS.EmployerUsers.Web.Models.HomePageViewModel
+@{
+    ViewBag.Title = "Page not found";
+    ViewBag.PageID = "page-not-found";
+    ViewBag.HideCookieMessage = true;
+    ViewBag.HideSigninLin = true;
 }
 
-</div>
+<h1 class="heading-xlarge">@ViewBag.Title</h1>
+<p>
+    If you entered a web address, check that it's correct.
+    @if(!string.IsNullOrEmpty(Model.ReturnUrl))
+    { 
+    <text>Otherwise <a href="@Model.ReturnUrl">Start again</a></text>
+    }
+</p>


### PR DESCRIPTION
Bug where if you go to root of IdP it returned a view, with a URL string; which runtime took to be view name. Now returns view with model and renders return url as ancor on page.