### PR TITLE
Check return urls from model then cookie

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.EmployerUsers.Web/Controllers/AccountController.cs
@@ -400,17 +400,21 @@ namespace SFA.DAS.EmployerUsers.Web.Controllers
             {
                 if (!string.IsNullOrEmpty(model.ReturnUrl))
                 {
-                    var returnUrl = _owinWrapper.GetIdsReturnUrl();
+                    return new RedirectResult(model.ReturnUrl);
+                }
+
+                var returnUrl = _owinWrapper.GetIdsReturnUrl();
+                if (!string.IsNullOrEmpty(returnUrl))
+                {
                     return new RedirectResult(returnUrl);
                 }
+
                 return await RedirectToEmployerPortal();
             }
 
             return View("ResetPassword", model);
         }
-
-
-
+        
         [HttpGet]
         [Authorize]
         [Route("account/changeemail")]


### PR DESCRIPTION
Check so that the return url is used from the response first, if it is
empty use the cookie, and if that is empty default to return to the
portal url