### PR TITLE
Update Identity Server Configuration

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Web/App_Start/Startup.IdentityServer.cs
+++ b/src/SFA.DAS.EmployerUsers.Web/App_Start/Startup.IdentityServer.cs
@@ -39,11 +39,11 @@ namespace SFA.DAS.EmployerUsers.Web
                 {
                     factory.AuthorizationCodeStore = new Registration<IAuthorizationCodeStore>(typeof(RedisAuthorizationCodeStore));
                 }
-                
+
                 idsrvApp.UseIdentityServer(new IdentityServerOptions
                 {
                     SiteName = "Digital Apprenticeship Service",
-                   
+
                     CspOptions = new CspOptions()
                     {
                         FontSrc = "* data:",
@@ -52,7 +52,11 @@ namespace SFA.DAS.EmployerUsers.Web
                         Enabled = false
                     },
                     SigningCertificate = LoadCertificate(),
-
+                    Endpoints = new EndpointOptions
+                    {
+                        EnableCheckSessionEndpoint = false,
+                        
+                    },
                     Factory = factory,
 
                     AuthenticationOptions = new AuthenticationOptions


### PR DESCRIPTION
Update the identity server configuration to turn off the
CheckSesssionEndpont so that the error is no longer logged when this
check fails