### PR TITLE
Don't throw exception when SignInMessage is not correct...

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenChangingPassword.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenChangingPassword.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using System.Web.Mvc;
+
 using Moq;
+using NLog;
 using NUnit.Framework;
 using SFA.DAS.Configuration;
 using SFA.DAS.EmployerUsers.Infrastructure.Configuration;
@@ -29,7 +31,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
             base.Arrange();
 
             AddUserToContext(UserId);
-
+            
             _accountOrchestrator = new Mock<AccountOrchestrator>();
             _accountOrchestrator.Setup(o => o.ChangePassword(It.IsAny<ChangePasswordViewModel>()))
                 .Throws(new System.Exception("Called AccountOrchestrator.ChangePassword with incorrect model"));
@@ -46,7 +48,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
 
             _configurationService = new Mock<IConfigurationService>();
 
-            _controller = new AccountController(_accountOrchestrator.Object, _owinWrapper.Object, new IdentityServerConfiguration());
+            _controller = new AccountController(_accountOrchestrator.Object, _owinWrapper.Object, new IdentityServerConfiguration(), _logger.Object);
             _controller.ControllerContext = _controllerContext.Object;
 
             _model = new ChangePasswordViewModel

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenConfirmingChangeEmail.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenConfirmingChangeEmail.cs
@@ -42,7 +42,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
 
             _owinWrapper = new Mock<IOwinWrapper>();
 
-            _controller = new AccountController(_accountOrchestrator.Object, _owinWrapper.Object, new IdentityServerConfiguration());
+            _controller = new AccountController(_accountOrchestrator.Object, _owinWrapper.Object, new IdentityServerConfiguration(), _logger.Object);
             _controller.ControllerContext = _controllerContext.Object;
 
             _model = new ConfirmChangeEmailViewModel

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenEnteringMyAccessCode.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenEnteringMyAccessCode.cs
@@ -33,7 +33,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
 
             _configurationService = new Mock<IConfigurationService>();
 
-            _accountController = new AccountController(_accountOrchestrator.Object, null, new IdentityServerConfiguration());
+            _accountController = new AccountController(_accountOrchestrator.Object, null, new IdentityServerConfiguration(), _logger.Object);
             _accountController.ControllerContext = _controllerContext.Object;
         }
 

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenLoggingIn.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenLoggingIn.cs
@@ -40,7 +40,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
 
 
 
-            _controller = new AccountController(_orchestrator.Object, _owinWrapper.Object, null);
+            _controller = new AccountController(_orchestrator.Object, _owinWrapper.Object, null, _logger.Object);
             _controller.ControllerContext = _controllerContext.Object;
         }
 

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenRegistering.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenRegistering.cs
@@ -32,7 +32,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
             _urlHelper.Setup(h => h.Action("Index", "Home", null, "https"))
                 .Returns("https://localhost/");
 
-            _accountController = new AccountController(_accountOrchestator.Object, null, null);
+            _accountController = new AccountController(_accountOrchestator.Object, null, null, _logger.Object);
             _accountController.ControllerContext = _controllerContext.Object;
             _accountController.Url = _urlHelper.Object;
         }

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenRequestingConfirmPage.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenRequestingConfirmPage.cs
@@ -23,7 +23,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
             _accountOrchestrator = new Mock<AccountOrchestrator>();
             _accountOrchestrator.Setup(o => o.RequestConfirmAccount(It.IsAny<string>())).Returns(Task.FromResult(true));
 
-            _controller = new AccountController(_accountOrchestrator.Object, null, null);
+            _controller = new AccountController(_accountOrchestrator.Object, null, null, _logger.Object);
             _controller.ControllerContext = _controllerContext.Object;
         }
 

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenRequestingPasswordReset.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenRequestingPasswordReset.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Web.Mvc;
 using Moq;
+using NLog;
 using NUnit.Framework;
 using SFA.DAS.Configuration;
 using SFA.DAS.EmployerUsers.Infrastructure.Configuration;
@@ -13,7 +15,7 @@ using SFA.DAS.EmployerUsers.Web.Orchestrators;
 namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
 {
     [TestFixture]
-    public class WhenRequestingPasswordReset
+    public class WhenRequestingPasswordReset 
     {
         private Mock<AccountOrchestrator> _accountOrchestrator;
         private Mock<IOwinWrapper> _owinWrapper;
@@ -21,11 +23,12 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
         private AccountController _accountController;
         private RequestPasswordResetViewModel _requestPasswordResetViewModel;
         private RequestPasswordResetViewModel _errorResponse;
+        private Mock<ILogger> _logger;
 
         [SetUp]
         public void Setup()
         {
-
+            _logger = new Mock<ILogger>();
             _requestPasswordResetViewModel = new RequestPasswordResetViewModel
             {
                 Email = "test.user@test.org"
@@ -45,7 +48,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
 
             _owinWrapper = new Mock<IOwinWrapper>();
             _configurationService = new Mock<IConfigurationService>();
-            _accountController = new AccountController(_accountOrchestrator.Object, _owinWrapper.Object, new IdentityServerConfiguration());
+            _accountController = new AccountController(_accountOrchestrator.Object, _owinWrapper.Object, new IdentityServerConfiguration(), _logger.Object);
 
         }
 

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenResendingActivationCode.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenResendingActivationCode.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
 
             _configurationService = new Mock<IConfigurationService>();
 
-            _accountController = new AccountController(_accountOrchestrator.Object, null, new IdentityServerConfiguration())
+            _accountController = new AccountController(_accountOrchestrator.Object, null, new IdentityServerConfiguration(), _logger.Object)
             {
                 ControllerContext = _controllerContext.Object
             };

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenResetingMyPassword.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenResetingMyPassword.cs
@@ -39,7 +39,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
             _owinWrapper.Setup(x => x.GetIdsReturnUrl()).Returns(ReturnUrl);
 
             var identityServerConfiguration = new IdentityServerConfiguration { EmployerPortalUrl = EmployerPortalReturnUrl };
-            _controller = new AccountController(_orchestrator.Object, _owinWrapper.Object, identityServerConfiguration);
+            _controller = new AccountController(_orchestrator.Object, _owinWrapper.Object, identityServerConfiguration, _logger.Object);
             _controller.ControllerContext = _controllerContext.Object;
         }
 

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenUnlockingMyAccount.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenUnlockingMyAccount.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
             _owinWrapper = new Mock<IOwinWrapper>();
 
             var identityServerConfiguration = new IdentityServerConfiguration {EmployerPortalUrl = EmployerPortalUrl};
-            _accountController = new AccountController(_accountOrchestrator.Object,_owinWrapper.Object, identityServerConfiguration);
+            _accountController = new AccountController(_accountOrchestrator.Object,_owinWrapper.Object, identityServerConfiguration, _logger.Object);
             _accountOrchestrator.Setup(x => x.UnlockUser(It.IsAny<UnlockUserViewModel>())).ReturnsAsync(new OrchestratorResponse<UnlockUserViewModel>() { Data = new UnlockUserViewModel {ErrorDictionary = new Dictionary<string, string>() }});
             _accountController.ControllerContext = _controllerContext.Object;
         }

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/ControllerTestBase.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/ControllerTestBase.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Web;
 using System.Web.Mvc;
 using Moq;
+using NLog;
 using SFA.DAS.EmployerUsers.WebClientComponents;
 
 namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers
@@ -12,9 +13,10 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers
         protected Mock<HttpRequestBase> _httpRequest;
         protected Mock<HttpContextBase> _httpContext;
         protected Mock<ControllerContext> _controllerContext;
-
+        protected Mock<ILogger> _logger;
         public virtual void Arrange()
         {
+            _logger = new Mock<ILogger>();
             _httpRequest = new Mock<HttpRequestBase>();
             _httpRequest.Setup(r => r.UserHostAddress).Returns("123.123.123.123");
             _httpRequest.Setup(r => r.Url).Returns(new Uri("https://localhost"));
@@ -25,6 +27,8 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers
 
             _controllerContext = new Mock<ControllerContext>();
             _controllerContext.Setup(c => c.HttpContext).Returns(_httpContext.Object);
+
+          
         }
 
         protected void AddUserToContext(string id = "USER_ID", string email = "my@local.com")

--- a/src/SFA.DAS.EmployerUsers.Web/Controllers/AccountController.cs
+++ b/src/SFA.DAS.EmployerUsers.Web/Controllers/AccountController.cs
@@ -7,6 +7,7 @@ using System.Web;
 using System.Web.Mvc;
 using SFA.DAS.EmployerUsers.Web.Authentication;
 using IdentityServer3.Core;
+using NLog;
 using SFA.DAS.EmployerUsers.Infrastructure.Configuration;
 using SFA.DAS.EmployerUsers.Web.Models;
 using SFA.DAS.EmployerUsers.Web.Models.SFA.DAS.EAS.Web.Models;
@@ -20,12 +21,14 @@ namespace SFA.DAS.EmployerUsers.Web.Controllers
         private readonly AccountOrchestrator _accountOrchestrator;
         private readonly IOwinWrapper _owinWrapper;
         private readonly IdentityServerConfiguration _identityServerConfiguration;
+        private readonly ILogger _logger;
 
-        public AccountController(AccountOrchestrator accountOrchestrator, IOwinWrapper owinWrapper, IdentityServerConfiguration identityServerConfiguration)
+        public AccountController(AccountOrchestrator accountOrchestrator, IOwinWrapper owinWrapper, IdentityServerConfiguration identityServerConfiguration, ILogger logger)
         {
             _accountOrchestrator = accountOrchestrator;
             _owinWrapper = owinWrapper;
             _identityServerConfiguration = identityServerConfiguration;
+            _logger = logger;
         }
 
 
@@ -106,7 +109,8 @@ namespace SFA.DAS.EmployerUsers.Web.Controllers
                 var signinMessage = _owinWrapper.GetSignInMessage(id);
                 if (signinMessage == null)
                 {
-                    throw new NullReferenceException($"Could not find signin message for id {id}");
+                   _logger.Info($"Could not find signin message for id {id}, Redirecting to Employer Portal");
+                    return await RedirectToEmployerPortal();
                 }
                 return Redirect(signinMessage.ReturnUrl);
             }


### PR DESCRIPTION
Log rather than throw and redirect to portal

Updated tests to include logger.