### PR TITLE
Change the email stored against security code

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Application.UnitTests/CommandsTests/RequestPasswordResetCodeTests/RequestPasswordResetCodeCommandTests/WhenHandlingTheCommand.cs
+++ b/src/SFA.DAS.EmployerUsers.Application.UnitTests/CommandsTests/RequestPasswordResetCodeTests/RequestPasswordResetCodeCommandTests/WhenHandlingTheCommand.cs
@@ -89,7 +89,7 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.CommandsTests.RequestPassw
             await _commandHandler.Handle(command);
 
             //Assert
-            _communicationSerivce.Verify(x => x.SendPasswordResetCodeMessage(It.IsAny<User>(), It.IsAny<string>()), Times.Never);
+            _communicationSerivce.Verify(x => x.SendPasswordResetCodeMessage(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             _userRepository.Verify(x => x.Update(It.IsAny<User>()), Times.Never);
         }
 
@@ -102,6 +102,7 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.CommandsTests.RequestPassw
             var expiryTime = DateTimeProvider.Current.UtcNow.AddHours(1);
             var existingUser = new User
             {
+                Id = _userId.ToString(),
                 Email = command.Email,
                 SecurityCodes = new[]
                 {
@@ -119,10 +120,10 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.CommandsTests.RequestPassw
             await _commandHandler.Handle(command);
 
             _communicationSerivce.Verify(x => x.SendPasswordResetCodeMessage(It.Is<User>(u => u.Email == existingUser.Email 
-                                                                                           && u.SecurityCodes.Any(sc => sc.Code == code
-                                                                                                                     && sc.CodeType == SecurityCodeType.PasswordResetCode
-                                                                                                                     && sc.ExpiryTime == expiryTime)
-                                                                                        ), It.IsAny<string>()), Times.Once);
+                                                                                              && u.SecurityCodes.Any(sc => sc.Code == code
+                                                                                                                           && sc.CodeType == SecurityCodeType.PasswordResetCode
+                                                                                                                           && sc.ExpiryTime == expiryTime)
+                ), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
         [Test]
@@ -155,10 +156,10 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.CommandsTests.RequestPassw
             await _commandHandler.Handle(command);
 
             _communicationSerivce.Verify(x => x.SendPasswordResetCodeMessage(It.Is<User>(u => u.Email == existingUser.Email 
-                                                                                                      && u.SecurityCodes.Any(sc => sc.Code == newCode
-                                                                                                                                && sc.CodeType == SecurityCodeType.PasswordResetCode
-                                                                                                                                && sc.ExpiryTime == DateTimeProvider.Current.UtcNow.AddDays(1))
-                                                                                        ), It.IsAny<string>()), Times.Once);
+                                                                                              && u.SecurityCodes.Any(sc => sc.Code == newCode
+                                                                                                                           && sc.CodeType == SecurityCodeType.PasswordResetCode
+                                                                                                                           && sc.ExpiryTime == DateTimeProvider.Current.UtcNow.AddDays(1))
+                ), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
         
 

--- a/src/SFA.DAS.EmployerUsers.Application.UnitTests/ServicesTests/NotificationTests/CommunicationServiceTests/WhenSendingANotification.cs
+++ b/src/SFA.DAS.EmployerUsers.Application.UnitTests/ServicesTests/NotificationTests/CommunicationServiceTests/WhenSendingANotification.cs
@@ -49,7 +49,7 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.ServicesTests.Notification
             await _communicationService.SendUserRegistrationMessage(user, "123");
             await _communicationService.SendAccountLockedMessage(user, "123");
             await _communicationService.ResendActivationCodeMessage(user, "123");
-            await _communicationService.SendPasswordResetCodeMessage(user, "123");
+            await _communicationService.SendPasswordResetCodeMessage(user, "123", It.IsAny<string>());
             await _communicationService.SendConfirmEmailChangeMessage(user, "123");
 
             //Assert

--- a/src/SFA.DAS.EmployerUsers.Application.UnitTests/ServicesTests/NotificationTests/CommunicationServiceTests/WhenSendingPasswordResetCodeMessage.cs
+++ b/src/SFA.DAS.EmployerUsers.Application.UnitTests/ServicesTests/NotificationTests/CommunicationServiceTests/WhenSendingPasswordResetCodeMessage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Moq;
 using NUnit.Framework;
 
 namespace SFA.DAS.EmployerUsers.Application.UnitTests.ServicesTests.NotificationTests.CommunicationServiceTests
@@ -35,7 +36,7 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.ServicesTests.Notification
 
         protected override async Task Act()
         {
-            await CommunicationService.SendPasswordResetCodeMessage(User, MessageId);
+            await CommunicationService.SendPasswordResetCodeMessage(User, MessageId, It.IsAny<string>());
         }
     }
 }

--- a/src/SFA.DAS.EmployerUsers.Application/Commands/RequestPasswordResetCode/RequestPasswordResetCodeCommandHandler.cs
+++ b/src/SFA.DAS.EmployerUsers.Application/Commands/RequestPasswordResetCode/RequestPasswordResetCodeCommandHandler.cs
@@ -67,7 +67,7 @@ namespace SFA.DAS.EmployerUsers.Application.Commands.RequestPasswordResetCode
                     Code = _codeGenerator.GenerateAlphaNumeric(),
                     CodeType = SecurityCodeType.PasswordResetCode,
                     ExpiryTime = DateTimeProvider.Current.UtcNow.AddDays(1),
-                    ReturnUrl = _linkBuilder.GetForgottenPasswordUrl(_hashingService.HashValue(Guid.Parse(existingUser.Id)))
+                    ReturnUrl = message.ReturnUrl
                 });
 
                 await _userRepository.Update(existingUser);
@@ -75,7 +75,7 @@ namespace SFA.DAS.EmployerUsers.Application.Commands.RequestPasswordResetCode
             
             await _auditService.WriteAudit(new PasswordResetCodeAuditMessage(existingUser));
 
-            await _communicationService.SendPasswordResetCodeMessage(existingUser, Guid.NewGuid().ToString());
+            await _communicationService.SendPasswordResetCodeMessage(existingUser, Guid.NewGuid().ToString(), _linkBuilder.GetForgottenPasswordUrl(_hashingService.HashValue(Guid.Parse(existingUser.Id))));
         }
 
         private static bool RequiresPasswordResetCode(User user)

--- a/src/SFA.DAS.EmployerUsers.Application/Services/Notification/CommunicationService.cs
+++ b/src/SFA.DAS.EmployerUsers.Application/Services/Notification/CommunicationService.cs
@@ -151,7 +151,7 @@ namespace SFA.DAS.EmployerUsers.Application.Services.Notification
             });
         }
 
-        public async Task SendPasswordResetCodeMessage(User user, string messageId)
+        public async Task SendPasswordResetCodeMessage(User user, string messageId, string getForgottenPasswordUrl)
         {
             var resetCode = GetUserPasswordResetCode(user);
 
@@ -168,7 +168,7 @@ namespace SFA.DAS.EmployerUsers.Application.Services.Notification
                         {
                             {"Code", resetCode.Code},
                             {"CodeExpiry", resetCode.ExpiryTime.ToString("d MMMM yyyy")},
-                            {"ReturnUrl", resetCode.ReturnUrl}
+                            {"ReturnUrl", getForgottenPasswordUrl}
                         }
                 });
             }

--- a/src/SFA.DAS.EmployerUsers.Application/Services/Notification/ICommunicationService.cs
+++ b/src/SFA.DAS.EmployerUsers.Application/Services/Notification/ICommunicationService.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.EmployerUsers.Application.Services.Notification
         Task ResendLastActivationCodeMessage(User user, string messageId);
         Task SendUserUnlockedMessage(User user, string messageId);
 
-        Task SendPasswordResetCodeMessage(User user, string messageId);
+        Task SendPasswordResetCodeMessage(User user, string messageId, string getForgottenPasswordUrl);
 
         Task SendConfirmEmailChangeMessage(User user, string messageId);
         Task SendNoAccountToPasswordResetMessage(string emailAddress, string messageId, string registerUrl);


### PR DESCRIPTION
Change made so that the URL that is stored security code is the return
url for the user, while the email shows the return url to the
application to continue the password reset journey