### PR TITLE
Adding api client certificate

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Api.Client/ClientCertificateStore.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/ClientCertificateStore.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace SFA.DAS.EmployerUsers.Api.Client
+{
+    public class ClientCertificateStore : IDisposable
+    {
+        private X509Store _store;
+
+        public ClientCertificateStore(X509Store store)
+        {
+            _store = store;
+            _store.Open(OpenFlags.ReadOnly);
+        }
+
+        public X509Certificate FindCertificateByThumbprint(string thumbprint)
+        {
+            return _store.Certificates.Find(X509FindType.FindByThumbprint, thumbprint, false)[0];
+        }
+
+        public void Dispose()
+        {
+            _store.Close();
+        }
+    }
+}

--- a/src/SFA.DAS.EmployerUsers.Api.Client/EmployerUsersApiConfiguration.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/EmployerUsersApiConfiguration.cs
@@ -26,5 +26,10 @@
         /// </summary>
         /// <example>xxxx.omicrosoft.com</example>
         public string Tenant { get; set; }
+
+        /// <summary>
+        /// X509 client certificate thumbprint
+        /// </summary>
+        public string ClientCertificateThumbprint { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerUsers.Api.Client/IEmployerUsersApiConfiguration.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/IEmployerUsersApiConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace SFA.DAS.EmployerUsers.Api.Client
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace SFA.DAS.EmployerUsers.Api.Client
 {
     public interface IEmployerUsersApiConfiguration
     {
@@ -29,5 +31,7 @@
         /// </summary>
         /// <example>xxxx.omicrosoft.com</example>
         string Tenant { get; }
+
+        string ClientCertificateThumbprint { get; }
     }
 }

--- a/src/SFA.DAS.EmployerUsers.Api.Client/SFA.DAS.EmployerUsers.Api.Client.csproj
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/SFA.DAS.EmployerUsers.Api.Client.csproj
@@ -44,6 +44,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -52,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClientCertificateStore.cs" />
     <Compile Include="EmployerUsersApiClient.cs" />
     <Compile Include="EmployerUsersApiConfiguration.cs" />
     <Compile Include="IEmployerUsersApiClient.cs" />

--- a/src/SFA.DAS.EmployerUsers.Api.Client/SecureHttpClient.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/SecureHttpClient.cs
@@ -27,9 +27,9 @@ namespace SFA.DAS.EmployerUsers.Api.Client
         {
             var authenticationResult = await GetAuthenticationResult(_configuration.ClientId, _configuration.ClientSecret, _configuration.IdentifierUri, _configuration.Tenant);
 
-            using (var client = new HttpClient())
             using (var store = new ClientCertificateStore(new X509Store(StoreLocation.LocalMachine)))
             using (var handler = new WebRequestHandler())
+            using (var client = new HttpClient(handler))
             {
                 client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", authenticationResult.AccessToken);
 


### PR DESCRIPTION
Production versions of the API need a X509 Certificate

this update allows the user to load a certificate by the thumbprint from their local machine

Closes #66