### PR TITLE
only adding the client certificate thumbprint when it's not null

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Api.Client/SecureHttpClient.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/SecureHttpClient.cs
@@ -33,10 +33,13 @@ namespace SFA.DAS.EmployerUsers.Api.Client
             {
                 client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", authenticationResult.AccessToken);
 
-                var certificate = store.FindCertificateByThumbprint(_configuration.ClientCertificateThumbprint);
-                if (certificate != null)
+                if (!string.IsNullOrEmpty(_configuration.ClientCertificateThumbprint))
                 {
-                    handler.ClientCertificates.Add(certificate);
+                    var certificate = store.FindCertificateByThumbprint(_configuration.ClientCertificateThumbprint);
+                    if (certificate != null)
+                    {
+                        handler.ClientCertificates.Add(certificate);
+                    }
                 }
 
                 var response = await client.GetAsync(url);


### PR DESCRIPTION
For local development and CI we don't have access to the client certificates so we'd like to leave it out.