### PR TITLE
Aml 1178 returnurl not populated

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Application.UnitTests/CommandsTests/UnlockUserTests/UnlockUserCommandTests/WhenHandlingTheCommand.cs
+++ b/src/SFA.DAS.EmployerUsers.Application.UnitTests/CommandsTests/UnlockUserTests/UnlockUserCommandTests/WhenHandlingTheCommand.cs
@@ -159,6 +159,7 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.CommandsTests.UnlockUserTe
         public void ThenAnAccountLockedEventIsRaisedIfTheValidationFailsAndTheUserIsNotNull()
         {
             //Arrange
+            var expectedReturnUrl = "http://local.test";
             _unlockUserCommandValidator.Setup(x => x.ValidateAsync(It.IsAny<UnlockUserCommand>())).ReturnsAsync(new ValidationResult { ValidationDictionary = { { "", "" } } });
             var unlockUserCommand = new UnlockUserCommand
             {
@@ -167,14 +168,15 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.CommandsTests.UnlockUserTe
                 User = new User
                 {
                     Email = ExpectedEmail
-                }
+                },
+                ReturnUrl = expectedReturnUrl
             };
 
             //Act
             Assert.ThrowsAsync<InvalidRequestException>(async () => await _unlockUserCommand.Handle(unlockUserCommand));
 
             //Assert
-            _mediator.Verify(x => x.PublishAsync(It.Is<AccountLockedEvent>(c => c.User.Email.Equals(ExpectedEmail))), Times.Once);
+            _mediator.Verify(x => x.PublishAsync(It.Is<AccountLockedEvent>(c => c.User.Email.Equals(ExpectedEmail) && c.ReturnUrl.Equals(expectedReturnUrl))), Times.Once);
         }
 
 

--- a/src/SFA.DAS.EmployerUsers.Application.UnitTests/EventsTests/AccountLockedTests/GenerateAndEmailAccountLockedEmailHandlerTests/WhenHandling.cs
+++ b/src/SFA.DAS.EmployerUsers.Application.UnitTests/EventsTests/AccountLockedTests/GenerateAndEmailAccountLockedEmailHandlerTests/WhenHandling.cs
@@ -250,6 +250,21 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.EventsTests.AccountLockedT
         }
 
         [Test]
+        public async Task ThenItShouldUseTheUrlFromTheRequestIfTheUnlockCodeIsNull()
+        {
+            //Arrange
+            _user.SecurityCodes = null;
+            _event.ReturnUrl = "http://test.local";
+
+            //Act
+            await _handler.Handle(_event);
+
+            //Assert
+            _communicationService.Verify(
+                s => s.SendAccountLockedMessage(It.Is<User>(c => c.SecurityCodes.Any(sc => sc.ReturnUrl == _event.ReturnUrl)),It.IsAny<string>()), Times.Once);
+        }
+
+        [Test]
         public async Task ThenTheUserShouldBeRetrievedByEmailIfTheIdIsNotProvided()
         {
             //Arrange

--- a/src/SFA.DAS.EmployerUsers.Application.UnitTests/EventsTests/AccountLockedTests/GenerateAndEmailAccountLockedEmailHandlerTests/WhenHandling.cs
+++ b/src/SFA.DAS.EmployerUsers.Application.UnitTests/EventsTests/AccountLockedTests/GenerateAndEmailAccountLockedEmailHandlerTests/WhenHandling.cs
@@ -83,6 +83,9 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.EventsTests.AccountLockedT
         [Test]
         public async Task ThenItShouldUpdateUserWithNewlyGeneratedCodeAndAnExpiryOf1DayIfNoCodeAttached()
         {
+            //Arrange
+            _event.ReturnUrl = "http://test.local";
+
             // Act
             await _handler.Handle(_event);
 
@@ -116,6 +119,9 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.EventsTests.AccountLockedT
         [Test]
         public async Task ThenItShouldSendUserNotificationIfNewCodeGenerated()
         {
+            //Arrange
+            _event.ReturnUrl = "http://test.local";
+
             // Act
             await _handler.Handle(_event);
 
@@ -158,7 +164,8 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.EventsTests.AccountLockedT
                 {
                     Code = "UNLOCK_CODE",
                     CodeType = SecurityCodeType.UnlockCode,
-                    ExpiryTime = DateTime.MinValue
+                    ExpiryTime = DateTime.MinValue,
+                    ReturnUrl = "http://test.local"
                 }
             };
 
@@ -234,7 +241,8 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.EventsTests.AccountLockedT
                 {
                     Code = "UNLOCK_CODE",
                     CodeType = SecurityCodeType.UnlockCode,
-                    ExpiryTime = DateTime.MinValue
+                    ExpiryTime = DateTime.MinValue,
+                    ReturnUrl = "http://test.local"
                 }
             };
 
@@ -270,6 +278,7 @@ namespace SFA.DAS.EmployerUsers.Application.UnitTests.EventsTests.AccountLockedT
             //Arrange
             _event.User.Id = null;
             _event.User.Email = UserEmail;
+            _event.ReturnUrl = "http://test.local";
 
             //Act
             await _handler.Handle(_event);

--- a/src/SFA.DAS.EmployerUsers.Application/Commands/UnlockUser/UnlockUserCommand.cs
+++ b/src/SFA.DAS.EmployerUsers.Application/Commands/UnlockUser/UnlockUserCommand.cs
@@ -8,5 +8,6 @@ namespace SFA.DAS.EmployerUsers.Application.Commands.UnlockUser
         public string UnlockCode { get; set; }
         public string Email { get; set; }
         public User User { get; set; }
+        public string ReturnUrl { get; set; }
     }
 }

--- a/src/SFA.DAS.EmployerUsers.Application/Commands/UnlockUser/UnlockUserCommandHandler.cs
+++ b/src/SFA.DAS.EmployerUsers.Application/Commands/UnlockUser/UnlockUserCommandHandler.cs
@@ -46,7 +46,7 @@ namespace SFA.DAS.EmployerUsers.Application.Commands.UnlockUser
             {
                 if (message.User != null)
                 {
-                    await _mediator.PublishAsync(new AccountLockedEvent { User = message.User });
+                    await _mediator.PublishAsync(new AccountLockedEvent { User = message.User, ReturnUrl = message.ReturnUrl});
                     await _auditService.WriteAudit(new FailedUnlockAuditMessage(message.User, message.UnlockCode));
                 }
                 throw new InvalidRequestException(result.ValidationDictionary);

--- a/src/SFA.DAS.EmployerUsers.Application/Events/AccountLocked/GenerateAndEmailAccountLockedEmailHandler.cs
+++ b/src/SFA.DAS.EmployerUsers.Application/Events/AccountLocked/GenerateAndEmailAccountLockedEmailHandler.cs
@@ -60,7 +60,7 @@ namespace SFA.DAS.EmployerUsers.Application.Events.AccountLocked
                     Code = await GenerateCode(),
                     CodeType = Domain.SecurityCodeType.UnlockCode,
                     ExpiryTime = DateTime.UtcNow.AddDays(1),
-                    ReturnUrl = notification.ReturnUrl
+                    ReturnUrl = notification.ReturnUrl ?? unlockCode.ReturnUrl
                 };
                 user.AddSecurityCode(unlockCode);
                 await _userRepository.Update(user);

--- a/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenUnlockingMyAccount.cs
+++ b/src/SFA.DAS.EmployerUsers.Web.UnitTests/Controllers/AccountControllerTests/WhenUnlockingMyAccount.cs
@@ -89,13 +89,14 @@ namespace SFA.DAS.EmployerUsers.Web.UnitTests.Controllers.AccountControllerTests
         {
             //Arrange
             var unlockCode = "123RET678";
-            var unlockUserViewModel = new UnlockUserViewModel {Email = LoggedInEmail, UnlockCode = unlockCode};
+            var returnUrl = "http://test.local";
+            var unlockUserViewModel = new UnlockUserViewModel {Email = LoggedInEmail, UnlockCode = unlockCode, ReturnUrl = returnUrl};
 
             //Act
             await _accountController.Unlock(unlockUserViewModel);
 
             //Assert
-            _accountOrchestrator.Verify(x=>x.UnlockUser(It.Is<UnlockUserViewModel>(c=>c.Email == LoggedInEmail && c.UnlockCode == unlockCode)));
+            _accountOrchestrator.Verify(x=>x.UnlockUser(It.Is<UnlockUserViewModel>(c=>c.Email == LoggedInEmail && c.UnlockCode == unlockCode && c.ReturnUrl == returnUrl)));
         }
 
         [Test]

--- a/src/SFA.DAS.EmployerUsers.Web/Orchestrators/AccountOrchestrator.cs
+++ b/src/SFA.DAS.EmployerUsers.Web/Orchestrators/AccountOrchestrator.cs
@@ -284,7 +284,8 @@ namespace SFA.DAS.EmployerUsers.Web.Orchestrators
                 var unlockResponse = await _mediator.SendAsync(new UnlockUserCommand
                 {
                     Email = unlockUserViewModel.Email,
-                    UnlockCode = unlockUserViewModel.UnlockCode
+                    UnlockCode = unlockUserViewModel.UnlockCode,
+                    ReturnUrl = unlockUserViewModel.ReturnUrl
                 });
 
                 await _mediator.SendAsync(new ActivateUserCommand


### PR DESCRIPTION
Fix for return url not being populated when the account locked message has been deleted by the cleanup job