### PR TITLE
#82 fix for Uri encoding of search criteria

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Api.Client/EmployerUsersApiClient.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/EmployerUsersApiClient.cs
@@ -37,7 +37,7 @@ namespace SFA.DAS.EmployerUsers.Api.Client
 
         public async Task<PagedApiResponseViewModel<UserSummaryViewModel>> SearchEmployerUsers(string criteria, int pageNumber = 1, int pageSize = 1000)
         {
-            return await GetResource<PagedApiResponseViewModel<UserSummaryViewModel>>($"/api/users/search/{criteria}/?pageNumber={pageNumber}&pageSize={pageSize}");
+            return await GetResource<PagedApiResponseViewModel<UserSummaryViewModel>>($"/api/users/search/{Uri.EscapeDataString(criteria)}/?pageNumber={pageNumber}&pageSize={pageSize}");
         }
     }
 }


### PR DESCRIPTION
This should fix the issue where we get a 404 instead of a search result if the criteria isn't escaped
