### PR TITLE
#82 fixing the url encoding of search and adding tests to validate it

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Api.Client.UnitTests/EmployerUsersApiClientTests/WhenGettingAPageOfEmployerUsers.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client.UnitTests/EmployerUsersApiClientTests/WhenGettingAPageOfEmployerUsers.cs
@@ -32,10 +32,11 @@ namespace SFA.DAS.EmployerUsers.Api.Client.UnitTests.EmployerUsersApiClientTests
                 }
             };
 
-            HttpClient.Setup(x => x.GetAsync(Configuration.ApiBaseUrl + $"api/users?pageNumber={pageNumber}&pageSize={pageSize}")).ReturnsAsync(JsonConvert.SerializeObject(expectedResult));
+            HttpClient.Setup(x => x.GetAsync(It.IsAny<string>())).ReturnsAsync(JsonConvert.SerializeObject(expectedResult));
 
             var response = await Client.GetPageOfEmployerUsers(pageNumber, pageSize);
 
+            HttpClient.Verify(x => x.GetAsync(Configuration.ApiBaseUrl + $"api/users?pageNumber={pageNumber}&pageSize={pageSize}"));
             response.ShouldBeEquivalentTo(expectedResult);
         }
     }

--- a/src/SFA.DAS.EmployerUsers.Api.Client.UnitTests/EmployerUsersApiClientTests/WhenGettingAnEmployerUser.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client.UnitTests/EmployerUsersApiClientTests/WhenGettingAnEmployerUser.cs
@@ -25,10 +25,11 @@ namespace SFA.DAS.EmployerUsers.Api.Client.UnitTests.EmployerUsersApiClientTests
                 FailedLoginAttempts = 3
             };
 
-            HttpClient.Setup(x => x.GetAsync(Configuration.ApiBaseUrl + resourceUri)).ReturnsAsync(JsonConvert.SerializeObject(expectedResult));
+            HttpClient.Setup(x => x.GetAsync(It.IsAny<string>())).ReturnsAsync(JsonConvert.SerializeObject(expectedResult));
 
             var response = await Client.GetResource<UserViewModel>(resourceUri);
 
+            HttpClient.Verify(x => x.GetAsync(Configuration.ApiBaseUrl + resourceUri));
             response.ShouldBeEquivalentTo(expectedResult);
         }
     }

--- a/src/SFA.DAS.EmployerUsers.Api.Client.UnitTests/SFA.DAS.EmployerUsers.Api.Client.UnitTests.csproj
+++ b/src/SFA.DAS.EmployerUsers.Api.Client.UnitTests/SFA.DAS.EmployerUsers.Api.Client.UnitTests.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="EmployerUsersApiClientTests\EmployerUsersApiClientTestsBase.cs" />
     <Compile Include="EmployerUsersApiClientTests\WhenGettingAnEmployerUser.cs" />
+    <Compile Include="EmployerUsersApiClientTests\WhenSearchingWithSpecialCharacters.cs" />
     <Compile Include="EmployerUsersApiClientTests\WhenSearchingEmployerUsers.cs" />
     <Compile Include="EmployerUsersApiClientTests\WhenGettingAPageOfEmployerUsers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/SFA.DAS.EmployerUsers.Api.Client/EmployerUsersApiClient.cs
+++ b/src/SFA.DAS.EmployerUsers.Api.Client/EmployerUsersApiClient.cs
@@ -25,8 +25,8 @@ namespace SFA.DAS.EmployerUsers.Api.Client
 
         public async Task<T> GetResource<T>(string resourceUri) where T : IEmployerUsersResource
         {
-            var absoluteUri = new Uri(new Uri(_configuration.ApiBaseUrl), resourceUri);
-            var json = await _secureHttpClient.GetAsync(absoluteUri.ToString());
+            var absoluteUri = Combine(_configuration.ApiBaseUrl, resourceUri);
+            var json = await _secureHttpClient.GetAsync(absoluteUri);
             return JsonConvert.DeserializeObject<T>(json);
         }
 
@@ -37,7 +37,19 @@ namespace SFA.DAS.EmployerUsers.Api.Client
 
         public async Task<PagedApiResponseViewModel<UserSummaryViewModel>> SearchEmployerUsers(string criteria, int pageNumber = 1, int pageSize = 1000)
         {
-            return await GetResource<PagedApiResponseViewModel<UserSummaryViewModel>>($"/api/users/search/{Uri.EscapeDataString(criteria)}/?pageNumber={pageNumber}&pageSize={pageSize}");
+            return await GetResource<PagedApiResponseViewModel<UserSummaryViewModel>>($"/api/users/search/{SanitiseUrl(criteria)}/?pageNumber={pageNumber}&pageSize={pageSize}");
+        }
+
+        private static string SanitiseUrl(string criteria)
+        {
+            return Uri.EscapeDataString(criteria).Replace(".", "%2E").Replace(" ", "%20");
+        }
+
+        public static string Combine(string uri1, string uri2)
+        {
+            uri1 = uri1.TrimEnd('/');
+            uri2 = uri2.TrimStart('/');
+            return $"{uri1}/{uri2}";
         }
     }
 }


### PR DESCRIPTION
I realised the last fix didn't work, I should have added tests.

![oh well](https://media.giphy.com/media/XsD8ammoDZwXK/giphy.gif)

I've changed your tests to use verify with the full url and setup against any url so it gets through the action portion of the test at least. 