### PR TITLE
Tokenize the WebSslCert thumbprint value

### DIFF
--- a/src/SFA.DAS.EmployerUsers/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.EmployerUsers/ServiceConfiguration.Cloud.cscfg
@@ -26,7 +26,7 @@
       <Setting name="AuditApiTenant" value="__AuditApiTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSslCert" thumbprint="__CertificateThumbprint__" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
 </ServiceConfiguration>

--- a/src/SFA.DAS.EmployerUsers/ServiceConfiguration.MO.cscfg
+++ b/src/SFA.DAS.EmployerUsers/ServiceConfiguration.MO.cscfg
@@ -26,7 +26,7 @@
       <Setting name="AuditApiTenant" value="__AuditApiTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSslCert" thumbprint="__CertificateThumbprint__" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
   <NetworkConfiguration>

--- a/src/SFA.DAS.EmployerUsers/ServiceConfiguration.PreProd.cscfg
+++ b/src/SFA.DAS.EmployerUsers/ServiceConfiguration.PreProd.cscfg
@@ -26,7 +26,7 @@
       <Setting name="AuditApiTenant" value="__AuditApiTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSslCert" thumbprint="__CertificateThumbprint__" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
   <NetworkConfiguration>

--- a/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.Cloud.cscfg
@@ -13,7 +13,7 @@
       <Setting name="idaTenant" value="__idaTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSSLCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSSLCert" thumbprint="__CertificateThumbprint__" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
 </ServiceConfiguration>

--- a/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.MO.cscfg
+++ b/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.MO.cscfg
@@ -13,7 +13,7 @@
       <Setting name="idaTenant" value="__idaTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSSLCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSSLCert" thumbprint="__CertificateThumbprint__" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
   <NetworkConfiguration>

--- a/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.PreProd.cscfg
+++ b/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.PreProd.cscfg
@@ -13,7 +13,7 @@
       <Setting name="idaTenant" value="__idaTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSSLCert" thumbprint="6DB782B8433D5F3DCA349DA4E2754CBABD5AD990" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSSLCert" thumbprint="__CertificateThumbprint__" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
   <NetworkConfiguration>


### PR DESCRIPTION
In preparation for `DASD-6790 - Replace employer users signing certificate with latest wildcard for dev/pp/mo` I've tokenized the WebSslCert thumbprint value in the devtest/pp/mo CSFG files for EmployerUsers and EmployerUsersApi. This is to make releases easier to manage rather than have to raise PRs to amend this value each time. 