### PR TITLE
Amended WebSslCert thumbprint value for DevTest (Cloud) csfg file to use new DevTest wildcard.

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Support.CloudService/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.EmployerUsers.Support.CloudService/ServiceConfiguration.Cloud.cscfg
@@ -10,7 +10,7 @@
       <Setting name="EmpUserApiCertificateThumbprint" value="__EmpUserApiCertificateThumbprint__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSslCert" thumbprint="847499EE2635A8C4C73416FE3B7830C54488AC8B" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
 </ServiceConfiguration>

--- a/src/SFA.DAS.EmployerUsers/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.EmployerUsers/ServiceConfiguration.Cloud.cscfg
@@ -26,7 +26,7 @@
       <Setting name="AuditApiTenant" value="__AuditApiTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSslCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSslCert" thumbprint="847499EE2635A8C4C73416FE3B7830C54488AC8B" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
 </ServiceConfiguration>

--- a/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.Cloud.cscfg
+++ b/src/SFA.DAS.EmployerUsersApi/ServiceConfiguration.Cloud.cscfg
@@ -13,7 +13,7 @@
       <Setting name="idaTenant" value="__idaTenant__" />
     </ConfigurationSettings>
     <Certificates>
-      <Certificate name="WebSSLCert" thumbprint="D4B7EBCE1013CBB10A6DD74D1A20E2C9A69107A2" thumbprintAlgorithm="sha1" />
+      <Certificate name="WebSSLCert" thumbprint="847499EE2635A8C4C73416FE3B7830C54488AC8B" thumbprintAlgorithm="sha1" />
     </Certificates>
   </Role>
 </ServiceConfiguration>


### PR DESCRIPTION
In order to use the new DevTest wildcard certificate, the WebSslCert thumbprint has been updated with the new thumbprint. 
