### PR TITLE
Employer Users Api: Allow additional identifier uri as audience

### DIFF
--- a/src/SFA.DAS.EmployerUsers.Api/App_Start/Startup.auth.cs
+++ b/src/SFA.DAS.EmployerUsers.Api/App_Start/Startup.auth.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.EmployerUsers.Api
                {
                    TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
                    {
-                       ValidAudience = CloudConfigurationManager.GetSetting("idaAudience"),
+                       ValidAudiences = CloudConfigurationManager.GetSetting("idaAudience").split(","),
                        RoleClaimType = "roles"
                    },
                    Tenant = CloudConfigurationManager.GetSetting("idaTenant")

--- a/src/SFA.DAS.EmployerUsers.Api/App_Start/Startup.auth.cs
+++ b/src/SFA.DAS.EmployerUsers.Api/App_Start/Startup.auth.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.EmployerUsers.Api
                {
                    TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
                    {
-                       ValidAudiences = CloudConfigurationManager.GetSetting("idaAudience").split(","),
+                       ValidAudiences = CloudConfigurationManager.GetSetting("idaAudience").Split(","),
                        RoleClaimType = "roles"
                    },
                    Tenant = CloudConfigurationManager.GetSetting("idaTenant")

--- a/src/SFA.DAS.EmployerUsers.Api/App_Start/Startup.auth.cs
+++ b/src/SFA.DAS.EmployerUsers.Api/App_Start/Startup.auth.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.EmployerUsers.Api
                {
                    TokenValidationParameters = new System.IdentityModel.Tokens.TokenValidationParameters
                    {
-                       ValidAudiences = CloudConfigurationManager.GetSetting("idaAudience").Split(","),
+                       ValidAudiences = CloudConfigurationManager.GetSetting("idaAudience").Split(','),
                        RoleClaimType = "roles"
                    },
                    Tenant = CloudConfigurationManager.GetSetting("idaTenant")


### PR DESCRIPTION
Employer Users Api: Allow additional identifier uri as audience

Additional identifier uri will be a standardised app registration, its' app roles will be granted to managed identities of function apps/app services that call the API